### PR TITLE
Update zef tooling

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -11,7 +11,7 @@ ENV LANG='C.UTF-8'
 ENV DEBIAN_FRONTEND='noninteractive'
 ENV TZ='Europe/Brussels'
 ENV pkgs_first="gpg ca-certificates debian-keyring debian-archive-keyring apt-transport-https curl"
-ENV PATH="/opt/rakudo-pkg/bin:/opt/rakudo-pkg/share/perl6/bin:/mnt/bin:${PATH}"
+ENV PATH="/opt/rakudo-pkg/var/zef/bin:/opt/rakudo-pkg/bin:/opt/rakudo-pkg/share/perl6/bin:/mnt/bin:${PATH}"
 ENV PERL6LIB="/mnt/lib"
 
 RUN apt-get update && apt-get install -y $pkgs_first && \
@@ -20,6 +20,7 @@ RUN apt-get update && apt-get install -y $pkgs_first && \
 RUN mkdir -p /usr/share/man/man1 && apt-get update && set -xv ;\
 apt-get install -y $(cat /Blin/docker/pkg-dependencies |grep -v '^#')
 RUN echo "    StrictHostKeyChecking no" >> /etc/ssh/ssh_config
+RUN /opt/rakudo-pkg/bin/install-zef
 RUN cd /Blin && zef install --verbose --deps-only .
 
 ENTRYPOINT [ "/Blin/docker/entrypoint.sh" ]

--- a/docker/pkg-dependencies
+++ b/docker/pkg-dependencies
@@ -24,6 +24,7 @@ libgit2-dev
 libglfw3
 libgtk-3-dev
 libgumbo-dev
+libgsl-dev
 libhidapi-dev
 libidn11-dev
 libidn2-dev

--- a/lib/Blin/Processing.rakumod
+++ b/lib/Blin/Processing.rakumod
@@ -376,6 +376,7 @@ sub test-module($full-commit-hash, $module,
         my %tweaked-env = %*ENV;
         %tweaked-env<PATH> = join ‘:’, $binary-path.parent, (%tweaked-env<PATH> // Empty);
         %tweaked-env<PERL6LIB> = $install-path.IO.absolute; # dump any precomp files here
+        %tweaked-env<RAKULIB> := %tweaked-env<PERL6LIB>;
         %tweaked-env<PERL6LIB> ~= ‘,’ ~ $tester.path.add: ‘/lib’;
         %tweaked-env<PERL6LIB> = join ‘,’, %tweaked-env<PERL6LIB>, # XXX looks fragile
                                    |@deps.map: { ‘inst#’ ~ .install-path.IO.absolute };

--- a/lib/Blin/Tester/Zef.rakumod
+++ b/lib/Blin/Tester/Zef.rakumod
@@ -30,10 +30,12 @@ submethod TWEAK ( ) {
         my $zef-config = from-json $0.Str.IO.slurp;
 
         # Turn auto-update off
-        for $zef-config<Repository>.list {
-            next unless .<module> eq ‘Zef::Repository::Ecosystems’;
-            .<options><auto-update> = 0; # XXX why is this not a boolean?
-            @!sources.push(.<options><mirrors>.head);
+        for $zef-config<Repository>.list -> $arr {
+            for @$arr {
+                next unless .<module> eq ‘Zef::Repository::Ecosystems’;
+                .<options><auto-update> = 0; # XXX why is this not a boolean?
+                @!sources.push(.<options><mirrors>.head);
+            }
         }
 
         $zef-config<RootDir>  = $zef-dumpster-path.absolute;

--- a/lib/Blin/Tester/Zef.rakumod
+++ b/lib/Blin/Tester/Zef.rakumod
@@ -23,7 +23,7 @@ submethod TWEAK ( ) {
 
     note ‘🥞 Creating a config file for zef’;
     {
-        run(:err, $zef-path.add(‘/bin/zef’), ‘--help’).err.slurp
+        run(:err, $*EXECUTABLE.absolute, ‘-I’, $zef-path, $zef-path.add(‘/bin/zef’), ‘--help’).err.slurp
           .match: /^^CONFIGURATION \s* (.*?)$$/;
 
         use JSON::Fast;
@@ -41,7 +41,7 @@ submethod TWEAK ( ) {
 
         spurt $zef-config-path, to-json $zef-config;
 
-        run $zef-path.add(‘/bin/zef’), “--config-path=$zef-config-path”, ‘update’;
+        run $*EXECUTABLE.absolute, ‘-I’, $zef-path, $zef-path.add(‘/bin/zef’), “--config-path=$zef-config-path”, ‘update’;
 
     }
 
@@ -59,6 +59,9 @@ submethod TWEAK ( ) {
 }
 
 method test-command( ::?CLASS:D: :$testable!, :$install-path!, :$module-name! ) {
+    $*EXECUTABLE.absolute,
+    ‘-I’,
+    $!path,
     $!binary,
     “--config-path=$!zef-config-path”,
     <--verbose --force-build --force-install>,

--- a/lib/Blin/Tester/Zef.rakumod
+++ b/lib/Blin/Tester/Zef.rakumod
@@ -54,16 +54,12 @@ submethod TWEAK ( ) {
 }
 
 method test-command( ::?CLASS:D: :$testable!, :$install-path!, :$module-name! ) {
-    $*EXECUTABLE.absolute,
-    ‘-I’,
-    $!path,
-    $!binary,
+    $!binary.absolute,
     “--config-path=$!zef-config-path”,
-    <--verbose --force-build --force-install>,
+    |<--verbose --force-build --force-install>,
     ($testable ?? ‘--force-test’ !! ‘--/test’),
-    <--/depends --/test-depends --/build-depends>,
+    |<--/depends --/test-depends --/build-depends>,
     ‘install’,
     “--to=inst#$install-path”,
     $module-name,
 }
-

--- a/lib/Blin/Tester/Zef.rakumod
+++ b/lib/Blin/Tester/Zef.rakumod
@@ -33,6 +33,7 @@ submethod TWEAK ( ) {
         for $zef-config<Repository>.list {
             next unless .<module> eq ‘Zef::Repository::Ecosystems’;
             .<options><auto-update> = 0; # XXX why is this not a boolean?
+            @!sources.push(.<options><mirrors>.head);
         }
 
         $zef-config<RootDir>  = $zef-dumpster-path.absolute;
@@ -44,12 +45,6 @@ submethod TWEAK ( ) {
         run $*EXECUTABLE.absolute, ‘-I’, $zef-path, $zef-path.add(‘/bin/zef’), “--config-path=$zef-config-path”, ‘update’;
 
     }
-
-    @!sources       = <
-      https://raw.githubusercontent.com/ugexe/Perl6-ecosystems/master/p6c.json
-      https://raw.githubusercontent.com/ugexe/Perl6-ecosystems/master/cpan.json
->;   # TODO steal that from zef automatically
-
 
     $!zef-config-path = $zef-config-path;
     $!path = $zef-path;


### PR DESCRIPTION
* Fixes issue with using the wrong libraries with bin/zef
* Extracts sources from zef config, which also enables Blin to source distributions from the new zef/fez ecosystem