### PR TITLE
Coke/systemd

### DIFF
--- a/lib/Blin/Debug.rakumod
+++ b/lib/Blin/Debug.rakumod
@@ -1,5 +1,5 @@
 unit class Blin::Debug is rw is export;
 
 our sub debug(Str $note, Int $level=1, :$icon="🥞") is export {
-    note "[{DateTime.now.truncated-to('second')} ] " ~ $icon x $level ~ ' ' ~ $note;
+    note "[{DateTime.now.truncated-to('second')}] " ~ $icon x $level ~ ' ' ~ $note;
 }

--- a/lib/Blin/Processing.rakumod
+++ b/lib/Blin/Processing.rakumod
@@ -14,6 +14,19 @@ use File::Directory::Tree;
 
 unit module Blin::Processing;
 
+# Get output from running command
+# Wrapper for Whateverable::Output::get-output that wraps the command
+# in a systemd-run call to prevent OOM errors from taking down everything
+
+sub get-wrapped-output(*@run-args, :$timeout, :$stdin, :$ENV, :$cwd = $*CWD, :$chomp = True) {
+    my @systemd-cmd = 'systemd-run', "--working-dir=$cwd", '--user', '--tty', '--wait', '--slice=user.slice';
+    for $ENV.keys -> $var {
+        @systemd-cmd.append: '-E', "$var={$ENV{$var}}";
+    }
+    @run-args.prepend: @systemd-cmd;
+    get-output(@run-args, :$stdin, :$cwd, :$chomp);
+}
+
 # Testing and Bisection
 
 # Keep in mind that here we are bisecting `fail`s only.
@@ -392,13 +405,13 @@ sub test-module($full-commit-hash, $module,
 
         my $result;
         if $module.test-script { # fake module
-            $result = get-output $binary-path,
+            $result = get-wrapped-output $binary-path,
                       ‘--’,
                       $module.test-script,
                       :stdin(‘’), :$timeout, ENV => %tweaked-env, :!chomp;
         } else { # normal module
 
-            $result = get-output $binary-path,
+            $result = get-wrapped-output $binary-path,
                       ‘--’,
                       $tester.test-command( :$testable, :$install-path, module-name => $module.name ),
                       :stdin(‘’), :$timeout, ENV => %tweaked-env, :!chomp;

--- a/lib/Blin/Processing.rakumod
+++ b/lib/Blin/Processing.rakumod
@@ -24,7 +24,7 @@ sub get-wrapped-output(*@run-args, :$timeout, :$stdin, :$ENV, :$cwd = $*CWD, :$c
         @systemd-cmd.append: '-E', "$var={$ENV{$var}}";
     }
     @run-args.prepend: @systemd-cmd;
-    get-output(@run-args, :$stdin, :$cwd, :$chomp);
+    get-output(@run-args, :$timeout, :$stdin, :$cwd, :$chomp);
 }
 
 # Testing and Bisection

--- a/util/summarize-overview.raku
+++ b/util/summarize-overview.raku
@@ -1,0 +1,10 @@
+#!/usr/bin/env raku
+
+my %counts;
+for "output/overview".IO.lines {
+    my ($module, $status) = .split(' – ');
+    %counts{$status//''}++;
+}
+
+use JSON::Fast;
+say to-json(%counts, :pretty, :sorted-keys);


### PR DESCRIPTION
Use systemd for individual test runs, not just the whole run.

Tweak OOM killer settings so the main blin process is less likely to die.

Add a utility for summarizing the running overview data.